### PR TITLE
Add <rsp> to User Modules

### DIFF
--- a/usermodules.reb
+++ b/usermodules.reb
@@ -11,6 +11,7 @@
     <pop3> [https://raw.githubusercontent.com/gchiu/Rebol3/master/protocols/prot-pop3.reb]
     <rebmu> [https://raw.githubusercontent.com/hostilefork/rebmu/master/rebmu.reb]
     <rem> [https://raw.githubusercontent.com/r3n/giuliolunati.renclib/master/usr/lib/r3/rem.reb]
+    <rsp> [https://raw.githubusercontent.com/rgchris/Scripts/master/ren-c/rsp.reb]
     <send> [https://raw.githubusercontent.com/gchiu/Rebol3/master/protocols/prot-send.reb]
     <smtp> [https://raw.githubusercontent.com/gchiu/Rebol3/master/protocols/prot-smtp.reb]
     <synctcp> [https://raw.githubusercontent.com/gchiu/Rebol3/master/protocols/prot-synctcp.reb]


### PR DESCRIPTION
Adds RSP to the user modules:

```rebol
import <rsp>

the-string: {€12 & £34}

print render {
    <% loop 3 [ %><p><%== the-string %></p><% ] %>
}
```